### PR TITLE
Change to secure websocket connections

### DIFF
--- a/drivers/webos_plus/lgtv2/lgtv2.js
+++ b/drivers/webos_plus/lgtv2/lgtv2.js
@@ -83,6 +83,18 @@ var LGTV = function (config) {
     }
     lastError = error.toString();
 
+	switch (error.code) {
+		case 'ECONNRESET':
+			config.newurl = new URL(config.url);
+			config.newurl.port = (config.newurl.port === '3000') ? '3001' : '3000';
+			config.newurl.protocol = (config.newurl.protocol === 'ws:') ? 'wss:' : 'ws:';
+			config.url = config.newurl.href;
+			delete config.newurl;
+			break;
+		default:
+			break;
+	}
+
     if (config.reconnect) {
       setTimeout(function () {
         if (autoReconnect) {
@@ -286,7 +298,7 @@ var LGTV = function (config) {
     } else if (!connection.connected) {
       that.emit('connecting', host);
       connection = {};
-      client.connect(host);
+      client.connect(host, null, null, null, { rejectUnauthorized: false });
     }
   };
 

--- a/drivers/webos_plus/webos/WebOSTV.js
+++ b/drivers/webos_plus/webos/WebOSTV.js
@@ -36,7 +36,7 @@ class WebOSTV extends Homey.Device {
    */
   _connect() {
     this.setAvailable();
-    this.log(`_connect: Connect to TV ${this.getSettings().ipAddress}`);
+    this.log(`_connect: Connect to TV wss://${this.getSettings().ipAddress}:3001`);
 
     this.lgtv = require('../lgtv2/lgtv2')({
       url: `ws://${this.getSettings().ipAddress}:3000`,


### PR DESCRIPTION
Change to connect over secure websockets to LG WebOS and ignore the certificate error UNABLE_TO_GET_ISSUER_CERT_LOCALLY.

Please verify if the secure websocket connections are also supported on older models. If not, this PR can be a starting point to allow both methods.
(See https://community.homey.app/t/lg-webos-better-integration/15007/433)