### PR TITLE
Fix the usePoll is undefined

### DIFF
--- a/drivers/webos_plus/device.js
+++ b/drivers/webos_plus/device.js
@@ -177,13 +177,13 @@ class WebosPlusDevice extends WebOSTV {
   }
 
   onSettings(oldSettings, newSettings, changedKeys) {
-    if (oldSettings.usePoll !== newSettings.usePoll){
+    if (oldSettings.usePoll !== newSettings?.usePoll){
       this.lgtv.disconnect();
       this.construct();
       this._connect();
       this.initDevice();
     }
-    if (newSettings.usePoll) {
+    if (newSettings?.usePoll) {
       this.poll();
     }
     return Promise.resolve(true);


### PR DESCRIPTION
I got the error message `Cannot read properties of undefined (reading 'usePoll')`, this fix uses optional chaining so if the object property does not exist, it will not fail.

This error can be reproduced by adding a TV device and then try to set the polling setting.

Related issue #59 where they also encountered the issue.